### PR TITLE
Updated to support Activiti Engine 5.12 and Grails 2.1

### DIFF
--- a/ActivitiGrailsPlugin.groovy
+++ b/ActivitiGrailsPlugin.groovy
@@ -31,7 +31,7 @@ import org.grails.activiti.serializable.SerializableVariableType
  */
 class ActivitiGrailsPlugin {
     // the plugin version
-    def version = "5.9"
+    def version = "5.12"
     // the version or versions of Grails the plugin is designed for
     def grailsVersion = "2.0.0 > *"
     // the other plugins this plugin depends on

--- a/grails-app/conf/BuildConfig.groovy
+++ b/grails-app/conf/BuildConfig.groovy
@@ -28,10 +28,10 @@ grails.project.dependency.resolution = {
         // specify dependencies here under either 'build', 'compile', 'runtime', 'test' or 'provided' scopes eg.
 
         // runtime 'mysql:mysql-connector-java:5.1.5'
-		compile ('org.activiti:activiti-engine:5.9') {
+		compile ('org.activiti:activiti-engine:5.12') {
 			excludes 'livetribe-jsr223'
 		}
-		runtime 'org.activiti:activiti-spring:5.9'
+		runtime 'org.activiti:activiti-spring:5.12'
 		runtime 'javax.mail:mail:1.4.1'
 		test 'org.subethamail:subethasmtp-smtp:1.2'
 		test 'org.subethamail:subethasmtp-wiser:1.2'

--- a/scripts/InstallVacationRequestSampleapp.groovy
+++ b/scripts/InstallVacationRequestSampleapp.groovy
@@ -53,8 +53,7 @@ private installStandardConfigFiles() {
 }
 
 private installSpringSecurityCoreFiles() {
-	ant.input(message:"Enter package name for User and Role domain classes:", addproperty:"packageName")
-	packageName = ant.antProject.properties["packageName"]
+	packageName = grailsConsole.userInput("Enter package name for User and Role domain classes:")
 	
 	ant.copy (todir:"${basedir}/grails-app/conf", overwrite: true) {
 		fileset dir:"${vacationRequestDir}/grails-app/conf/springSecurity"

--- a/src/groovy/org/grails/activiti/serializable/SerializableVariableType.groovy
+++ b/src/groovy/org/grails/activiti/serializable/SerializableVariableType.groovy
@@ -1,12 +1,13 @@
 package org.grails.activiti.serializable
 
 import org.activiti.engine.ActivitiException
+import org.activiti.engine.impl.bpmn.data.ItemInstance
+import org.activiti.engine.impl.bpmn.webservice.MessageInstance
+import org.activiti.engine.impl.context.Context
 import org.activiti.engine.impl.persistence.entity.VariableInstanceEntity
+import org.activiti.engine.impl.util.IoUtil
 import org.activiti.engine.impl.variable.ByteArrayType
 import org.activiti.engine.impl.variable.ValueFields
-import org.activiti.engine.impl.util.IoUtil
-import org.activiti.engine.impl.context.Context
-import org.grails.activiti.serializable.GroovyObjectInputStream
 
 /**
  *
@@ -78,9 +79,29 @@ class SerializableVariableType extends ByteArrayType {
         return baos.toByteArray()
     }
 
-    boolean isAbleToStore(Object value) {
-        return value instanceof Serializable;
-    }
+	boolean isAbleToStore(Object value) {
+		if (value==null) {
+			return false;
+		}
+		Class theclass = value.getClass();
+		boolean isAssignable = (
+				byte[].class.isAssignableFrom(theclass)
+				|| String.class.isAssignableFrom(value.getClass())
+				|| Boolean.class.isAssignableFrom(value.getClass())
+				|| boolean.class.isAssignableFrom(value.getClass())
+				|| Short.class.isAssignableFrom(value.getClass())
+				|| short.class.isAssignableFrom(value.getClass())
+				|| Integer.class.isAssignableFrom(value.getClass())
+				|| int.class.isAssignableFrom(value.getClass())
+				|| Long.class.isAssignableFrom(value.getClass())
+				|| long.class.isAssignableFrom(value.getClass())
+				|| Date.class.isAssignableFrom(value.getClass())
+				|| Double.class.isAssignableFrom(value.getClass())
+				|| ItemInstance.class.isAssignableFrom(theclass)
+				|| MessageInstance.class.isAssignableFrom(theclass)
+				);
+		return (!isAssignable && value instanceof Serializable);
+	}
 }
 
 


### PR DESCRIPTION
Updated for Activiti 5.12, 
Changed SerializableVariableType so that custom  serializer is not used for primitive types and there object counterparts,
Changed Vacation Request sample installer to use Grail 2.1-supported method of prompting for package name.
