### PR TITLE
Added load order dependency with hibernate, gorm

### DIFF
--- a/ActivitiGrailsPlugin.groovy
+++ b/ActivitiGrailsPlugin.groovy
@@ -37,7 +37,7 @@ class ActivitiGrailsPlugin {
     // the other plugins this plugin depends on
     def dependsOn = [:]
     // load after hibernate and gorm if present
-    def loadAfter = [ 'hibernate', 'gorm' ]
+    def loadAfter = [ 'hibernate', 'hibernate4', 'gorm' ]
     // resources that are excluded from plugin packaging
     def pluginExcludes = [
             "grails-app/views/error.gsp"

--- a/ActivitiGrailsPlugin.groovy
+++ b/ActivitiGrailsPlugin.groovy
@@ -36,6 +36,8 @@ class ActivitiGrailsPlugin {
     def grailsVersion = "2.0.0 > *"
     // the other plugins this plugin depends on
     def dependsOn = [:]
+    // load after hibernate and gorm if present
+    def loadAfter = [ 'hibernate', 'gorm' ]
     // resources that are excluded from plugin packaging
     def pluginExcludes = [
             "grails-app/views/error.gsp"


### PR DESCRIPTION
Added load order dependency with hibernate and gorm to ensure the methods they add to the domain classes are already present by the time activiti loads, in case a task fired at start-up will need them.
This can happen if we have a timer-triggered task with a timer that is overdue when the plug-in starts (i.e. because the application was down when it was programmed to fire). As soon as the plugin loads, the overdue timer is triggered and the task/process attached to it fire. If the task happens to call a method that uses a GORM-autogenerated method (`findBy*`, etc.) and the gorm/hibernate plugins haven't loaded yet, the call to the method will fail.
