### PR TITLE
Upgrade to 2.4.x

### DIFF
--- a/src/groovy/org/grails/activiti/ActivitiUtils.groovy
+++ b/src/groovy/org/grails/activiti/ActivitiUtils.groovy
@@ -20,10 +20,10 @@ package org.grails.activiti
  *
  * @since 5.0.beta2
  */
-import org.codehaus.groovy.grails.commons.ApplicationHolder
+import Holders.grailsApplication;
 
 class ActivitiUtils {
-	static def context = ApplicationHolder.getApplication().getMainContext()
+	static def context = grailsApplication.application.getMainContext()
 	
 	static getActivitiService() {
 		context.getBean("activitiService")


### PR DESCRIPTION
The following deprecated classes have been removed from Grails 2.4.x:

``` groovy
org.codehaus.groovy.grails.commons.ApplicationHolder
org.codehaus.groovy.grails.commons.ConfigurationHolder
org.codehaus.groovy.grails.plugins.PluginManagerHolder
org.codehaus.groovy.grails.web.context.ServletContextHolder
org.codehaus.groovy.grails.compiler.support.GrailsResourceLoaderHolder
```

If you or any plugins you have installed are using these classes you will get a compilation error. The problem can be rectified by updating to new plugins and using grails.util.Holders instead.

For example

application = org.codehaus.groovy.grails.commons.ApplicationHolder.application 

to

``` groovy
application = Holders.grailsApplication
```
